### PR TITLE
Change SWM logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mix test --include soundcard
 
 Copyright 2018, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane-element-portaudio)
 
-[![Software Mansion](https://membraneframework.github.io/static/logo/swm_logo_readme.png)](
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](
 https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane-element-portaudio)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)


### PR DESCRIPTION
<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>